### PR TITLE
replace AOSP CarrierConfig with GrapheneOS CarrierConfig2

### DIFF
--- a/common/overlay/packages/providers/TelephonyProvider/res/values/config.xml
+++ b/common/overlay/packages/providers/TelephonyProvider/res/values/config.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="apn_source_service" translatable="false">app.grapheneos.carrierconfig2/.ApnServiceImpl</string>
+</resources>

--- a/common/overlay/packages/services/Telephony/res/values/config.xml
+++ b/common/overlay/packages/services/Telephony/res/values/config.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="platform_carrier_config_package" translatable="false">app.grapheneos.carrierconfig2</string>
+</resources>

--- a/common/pixel-common-device.mk
+++ b/common/pixel-common-device.mk
@@ -39,3 +39,10 @@ BOARD_VENDOR_SEPOLICY_DIRS += hardware/google/pixel-sepolicy/wifi_perf_diag
 # but also allow explicit overriding for testing and development.
 SYSTEM_OPTIMIZE_JAVA ?= true
 SYSTEMUI_OPTIMIZE_JAVA ?= true
+
+DEVICE_PACKAGE_OVERLAYS += hardware/google/pixel/common/overlay
+
+ifneq ($(BOARD_WITHOUT_RADIO),true)
+    PRODUCT_PACKAGES += \
+        CarrierConfig2
+endif


### PR DESCRIPTION
Part of a changelist:

https://github.com/muhomorr/platform_packages_apps_CarrierConfig2
https://github.com/GrapheneOS/platform_manifest/pull/20

https://github.com/GrapheneOS/device_google_coral/pull/46
https://github.com/GrapheneOS/device_google_sunfish/pull/33
https://github.com/GrapheneOS/device_google_redbull/pull/32
https://github.com/GrapheneOS/device_google_gs101/pull/32
https://github.com/GrapheneOS/device_google_gs201/pull/10